### PR TITLE
WebHost: Fix as_dict attribute error (#1977)

### DIFF
--- a/Main.py
+++ b/Main.py
@@ -23,7 +23,8 @@ __all__ = ["main"]
 
 def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = None):
     if not baked_server_options:
-        baked_server_options = get_settings().server_options
+        baked_server_options = get_settings().server_options.as_dict()
+    assert isinstance(baked_server_options, dict)
     if args.outputpath:
         os.makedirs(args.outputpath, exist_ok=True)
         output_path.cached_path = args.outputpath
@@ -372,7 +373,7 @@ def main(args, seed=None, baked_server_options: Optional[Dict[str, object]] = No
                     "connect_names": {name: (0, player) for player, name in world.player_name.items()},
                     "locations": locations_data,
                     "checks_in_area": checks_in_area,
-                    "server_options": baked_server_options.as_dict(),
+                    "server_options": baked_server_options,
                     "er_hint_data": er_hint_data,
                     "precollected_items": precollected_items,
                     "precollected_hints": precollected_hints,


### PR DESCRIPTION
* WebHost: Fix as_dict attribute error

Introduced in 827444f5a4e065bc310c889892580eb1f97c73cb

* WebHost: Add assertion that baked_server_options is a dict



---------

Please format your title with what portion of the project this pull request is
targeting and what it's changing.

ex. "MyGame4: implement new game" or "Docs: add new guide for customizing MyGame3"

## What is this fixing or adding?


## How was this tested?


## If this makes graphical changes, please attach screenshots.
